### PR TITLE
Add support for ssh command line options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,8 +61,8 @@ You can specify additional command line options (see `man ssh`) as follows:
     {
         "targets": [
             {
-                "host": "An example target listening non-standard port and verbose flag",
-                "friendly": "This is an example target", 
+                "host": "user@example-machine.local",
+                "friendly": "An example target listening non-standard port and verbose flag", 
                 "options" : [
                     "-p443",
                     "-v"

--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,14 @@ sshmenu
 -------
 ``sshmenu`` is a simple tool for connecting to remote hosts via ssh. Great if you have trouble remembering ip addresses, hostnames, or usernames.
 
-This tool works by using Python's ``os.execlp(...)``, which will replace the current process (python) with ``ssh``.
+This tool works by using Python's ``os.execvp(...)``, which will replace the current process (python) with ``ssh``.
 
 .. image:: http://i.imgur.com/X1jaoci.gif
 
 
 Installation
 ------------
-Tested working on OS X El Capitan (10.11.5) and Ubuntu Xenial Xerus (16.04)
+Tested working on OS X El Capitan (10.11.5) and Ubuntu Trusty Tahr (14.04), Xenial Xerus (16.04)
 
 
 **OS X**
@@ -45,12 +45,30 @@ On first run an example configuration file will be created for you, along with t
 .. code-block:: json
 
     {
-      "targets" : [
-        {
-          "friendly" : "This is an example target",
-          "host" : "user@example-machine.local"
-        }
-      ]
+        "targets": [
+            {
+                "host": "user@example-machine.local",
+                "friendly": "This is an example target",
+                "options": []
+            }
+        ]
+    }
+
+You can specify additional command line options (see `man ssh`) as follows:
+
+.. code-block:: json
+    
+    {
+        "targets": [
+            {
+                "host": "An example target listening non-standard port and verbose flag",
+                "friendly": "This is an example target", 
+                "options" : [
+                    "-p443",
+                    "-v"
+                ]
+            }
+        ]
     }
 
 Todo

--- a/sshmenu/sshmenu.py
+++ b/sshmenu/sshmenu.py
@@ -18,11 +18,11 @@ def main():
                 {
                     'host': 'user@example-machine.local',
                     'friendly': 'This is an example target',
-                    'options': {}
+                    'options' : []
                 }
             ]
         }
-        resources.user.write('config.json', json.dumps(example_config))
+        resources.user.write('config.json', json.dumps(example_config, indent=4))
         puts('I have created a new configuration file, please edit and run again:')
         puts(resources.user.path + '/config.json')
     else:
@@ -81,8 +81,10 @@ def display_menu(targets):
             # For cleanliness clear the screen
             call(['tput', 'clear'])
 
+            target = targets[selected_target]
+            # Arguments to the child process should start with the name of the command being run
+            args = ['ssh'] + target.get('options', []) + [target['host']]
             # After this line, ssh will replace the python process
-            options = ['-{}{}'.format(opt, val) for opt, val in targets[selected_target].get('options', {}).items()]
-            os.execlp('ssh', 'ssh', targets[selected_target]['host'], *options)
+            os.execvp('ssh', args)
         elif key == readchar.key.CTRL_C:
             exit(0)

--- a/sshmenu/sshmenu.py
+++ b/sshmenu/sshmenu.py
@@ -17,7 +17,8 @@ def main():
             'targets': [
                 {
                     'host': 'user@example-machine.local',
-                    'friendly': 'This is an example target'
+                    'friendly': 'This is an example target',
+                    'options': {}
                 }
             ]
         }
@@ -81,6 +82,7 @@ def display_menu(targets):
             call(['tput', 'clear'])
 
             # After this line, ssh will replace the python process
-            os.execlp('ssh', 'ssh', targets[selected_target]['host'])
+            options = ['-{}{}'.format(opt, val) for opt, val in targets[selected_target].get('options', {}).items()]
+            os.execlp('ssh', 'ssh', targets[selected_target]['host'], *options)
         elif key == readchar.key.CTRL_C:
             exit(0)


### PR DESCRIPTION
Fixes #1 
Adds "options" configuration key

``` json
{"targets": [
    {
        "friendly": "altssh dev server available behind firewall",
        "host": "user@dev.alt",
        "options": {
            "p": "443"          
        }
    }
]}
```

Will execute `ssh user@test.dev -p 443`
