### PR TITLE
Added some movement options to make it easier to navigate if you have a lot of targets + support for other commands in addition to "ssh".

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ On first run an example configuration file will be created for you, along with t
                 "options": []
             },
             {
-                "command": "ssh"
+                "command": "ssh",
                 "host": "user@example-machine.local",
                 "friendly": "This is an example target",
                 "options": []

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,12 @@ On first run an example configuration file will be created for you, along with t
                 "host": "user@example-machine.local",
                 "friendly": "This is an example target",
                 "options": []
+            },
+            {
+                "command": "ssh"
+                "host": "user@example-machine.local",
+                "friendly": "This is an example target",
+                "options": []
             }
         ]
     }

--- a/sshmenu/sshmenu.py
+++ b/sshmenu/sshmenu.py
@@ -119,7 +119,7 @@ def display_menu(targets):
             if round(time.time()) - number_last <= 1:
                 number_buffer += key
                 requested_target = int(''.join(number_buffer))
-                # If the new target is invalid, just keep the key press instead
+                # If the new target is invalid, just keep the previously selected target instead
                 if requested_target >= num_targets:
                     requested_target = selected_target
             else:
@@ -138,12 +138,14 @@ def display_menu(targets):
             call(['tput', 'clear'])
 
             target = targets[selected_target]
-            # Arguments to the child process should start with the name of the command being run
+
+            # Check if there is a custom command for this target
             if 'command' in target.keys():
                 command = target['command']
             else:
                 command = 'ssh'
             
+            # Arguments to the child process should start with the name of the command being run
             args = [command] + target.get('options', []) + [target['host']]
             # After this line, ssh will replace the python process
             try:

--- a/sshmenu/sshmenu.py
+++ b/sshmenu/sshmenu.py
@@ -1,8 +1,10 @@
 import json
 import os
 import readchar
-from subprocess import call
+import sys
+import time
 
+from subprocess import call
 from clint import resources
 from clint.textui import puts, colored
 
@@ -16,6 +18,12 @@ def main():
         example_config = {
             'targets': [
                 {
+                    'host': 'user@example-machine.local',
+                    'friendly': 'This is an example target',
+                    'options' : []
+                },
+                {
+                    'command': 'ssh',
                     'host': 'user@example-machine.local',
                     'friendly': 'This is an example target',
                     'options' : []
@@ -46,13 +54,17 @@ def display_menu(targets):
 
     # Clear screen, give instructions
     call(['tput', 'clear'])
-    puts(colored.cyan('Select a target (up, down, enter, ctrl+c to exit)'))
+    puts(colored.cyan('Select a target (up (k), down (j), enter, ctrl+c to exit)'))
 
     # Save current cursor position so we can overwrite on list updates
     call(['tput', 'sc'])
 
     # Keep track of currently selected target
     selected_target = 0
+    
+    # Support input of long numbers
+    number_buffer = []
+    number_last = round(time.time()) # Store time of last number that was entered
 
     while True:
         # Return to the saved cursor position
@@ -60,7 +72,7 @@ def display_menu(targets):
 
         # Print items
         for index, target in enumerate(targets):
-            desc = target['host'].ljust(longest_host) + ' | ' + target['friendly']
+            desc = '%2d ' % (index) + target['host'].ljust(longest_host) + ' | ' + target['friendly']
             if index == selected_target:
                 puts(colored.green(' -> ' + desc))
             else:
@@ -69,22 +81,75 @@ def display_menu(targets):
         # Hang until we get a keypress
         key = readchar.readkey()
 
-        if key == readchar.key.UP:
+        if key == readchar.key.UP or key == 'k':
             # Ensure the new selection would be valid
             if (selected_target - 1) >= 0:
                 selected_target -= 1
-        elif key == readchar.key.DOWN:
+
+            # Empty the number buffer
+            number_buffer = []
+
+        elif key == readchar.key.DOWN or key == 'j':
             # Ensure the new selection would be valid
             if (selected_target + 1) <= (num_targets - 1):
                 selected_target += 1
+
+            # Empty the number buffer
+            number_buffer = []
+
+        elif key == 'g':
+            # Go to top
+            selected_target = 0
+
+            # Empty the number buffer
+            number_buffer = []
+
+        elif key == 'G':
+            # Go to bottom
+            selected_target = num_targets - 1
+
+            # Empty the number buffer
+            number_buffer = []
+
+        # Check if key is a number
+        elif key in map(lambda x: str(x), range(10)):
+            requested_target = int(key)
+
+            # Check if there are any previously entered numbers, and append if less than one second has gone by
+            if round(time.time()) - number_last <= 1:
+                number_buffer += key
+                requested_target = int(''.join(number_buffer))
+                # If the new target is invalid, just keep the key press instead
+                if requested_target >= num_targets:
+                    requested_target = selected_target
+            else:
+                number_buffer = [key]
+
+            number_last = round(time.time())
+
+            # Ensure the new selection would be valid
+            if requested_target >= num_targets:
+                requested_target = num_targets - 1
+
+            selected_target = requested_target
+
         elif key == readchar.key.ENTER:
             # For cleanliness clear the screen
             call(['tput', 'clear'])
 
             target = targets[selected_target]
             # Arguments to the child process should start with the name of the command being run
-            args = ['ssh'] + target.get('options', []) + [target['host']]
+            if 'command' in target.keys():
+                command = target['command']
+            else:
+                command = 'ssh'
+            
+            args = [command] + target.get('options', []) + [target['host']]
             # After this line, ssh will replace the python process
-            os.execvp('ssh', args)
+            try:
+                os.execvp(command, args)
+            except FileNotFoundError:
+                sys.exit('command not found: {commandname}'.format(commandname = command))
+
         elif key == readchar.key.CTRL_C:
             exit(0)


### PR DESCRIPTION
sshmenu is awesome as is, but I needed some more options to make it perfect for me. I have a lot of ssh targets, so I wanted an easier way to navigate. I also use "clogin" to login to routers and switches, so I needed support for custom commands.

Hopefully these additions will be helpful to more people :-)

Details:
Added ability to change "ssh" to another command. "ssh" is the default if no "command" key is specified in the target's config.

Added more menu movement options:
- You can go up by pressing k.
- You can go down by pressing j.
- Move to the bottom of the list with upper-case G.
- Move to the top of the list with lower-case g.
- You can input numbers to move to the corresponding numbered line. Example: Type "5" to move to line number 5, type "15" to move to line number 15, etc...

To make it easier to jump to a numbered line, the line numbers are visible in the menu.
Readme has been updated with an example showing the "command" config key. The default example config that is written by sshmenu on the first run also includes this example.
