### PR TITLE
Scrollable target list + support for multiple config files

### DIFF
--- a/sshmenu/sshmenu.py
+++ b/sshmenu/sshmenu.py
@@ -96,7 +96,7 @@ def display_menu(targets):
 
     while True:
         # Calculate height of terminal window in case it has been resized
-        terminal_height = get_terminal_height()
+        new_terminal_height = get_terminal_height()
         # Return to the saved cursor position
         call(['tput', 'rc'])
 
@@ -104,12 +104,22 @@ def display_menu(targets):
         puts(colored.cyan('Select a target (up (k), down (j), enter, ctrl+c to exit)'))
 
         # Recalculate visible targets based on selected_target
-        if selected_target > max(visible_target_range):
+        move_down = False
+        move_up = False
+        if terminal_height != new_terminal_height:
+            if selected_target + (terminal_height - 2) > num_targets:
+                move_down = True
+            else:
+                move_up = True
+
+            terminal_height = new_terminal_height
+
+        if selected_target > max(visible_target_range) or move_down:
             visible_start = selected_target - terminal_height + 3
             visible_end = selected_target + 1
             visible_target_range = range(visible_start, visible_end)
 
-        elif selected_target < min(visible_target_range):
+        elif selected_target < min(visible_target_range) or move_up:
             visible_start = selected_target
             visible_end = selected_target + terminal_height - 2
             visible_target_range = range(visible_start, visible_end)

--- a/sshmenu/sshmenu.py
+++ b/sshmenu/sshmenu.py
@@ -103,23 +103,28 @@ def display_menu(targets):
         # Redraw the instructions to make sure they don't disappear when resizing terminal
         puts(colored.cyan('Select a target (up (k), down (j), enter, ctrl+c to exit)'))
 
-        # Recalculate visible targets based on selected_target
+        # Check if the terminal height has changed
         move_down = False
         move_up = False
         if terminal_height != new_terminal_height:
-            if selected_target + (terminal_height - 2) > num_targets:
+            terminal_height = new_terminal_height
+            if selected_target >= (terminal_height - 3):
                 move_down = True
             else:
                 move_up = True
 
-            terminal_height = new_terminal_height
-
-        if selected_target > max(visible_target_range) or move_down:
+        # Recalculate visible targets based on selected_target
+        if move_down:
             visible_start = selected_target - terminal_height + 3
             visible_end = selected_target + 1
             visible_target_range = range(visible_start, visible_end)
-
-        elif selected_target < min(visible_target_range) or move_up:
+        elif move_up:
+            visible_target_range = range(terminal_height - 2)
+        elif selected_target > max(visible_target_range):
+            visible_start = selected_target - terminal_height + 3
+            visible_end = selected_target + 1
+            visible_target_range = range(visible_start, visible_end)
+        elif selected_target < min(visible_target_range):
             visible_start = selected_target
             visible_end = selected_target + terminal_height - 2
             visible_target_range = range(visible_start, visible_end)

--- a/sshmenu/sshmenu.py
+++ b/sshmenu/sshmenu.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import os
 import readchar
@@ -11,11 +12,16 @@ from clint.textui import puts, colored
 
 
 def main():
+    # Check arguments
+    parser = argparse.ArgumentParser(prog='sshmenu', description='A simple tool for connecting to remote hosts via ssh.')
+    parser.add_argument('-c', '--configname', default='config.json', help='Specify an alternative configuration name.')
+    args = parser.parse_args()
+
     # First parameter is 'company' name, hence duplicate arguments
     resources.init('sshmenu', 'sshmenu')
 
-    # For the first run, create an example config
-    if resources.user.read('config.json') is None:
+    # If the config file doesn't exist, create an example config
+    if resources.user.read(args.configname) is None:
         example_config = {
             'targets': [
                 {
@@ -31,20 +37,20 @@ def main():
                 }
             ]
         }
-        resources.user.write('config.json', json.dumps(example_config, indent=4))
+        resources.user.write(args.configname, json.dumps(example_config, indent=4))
         puts('I have created a new configuration file, please edit and run again:')
-        puts(resources.user.path + os.path.sep + 'config.json')
+        puts(resources.user.path + os.path.sep + args.configname)
     else:
-        config = json.loads(resources.user.read('config.json'))
+        config = json.loads(resources.user.read(args.configname))
         display_menu(config['targets'])
 
 def get_terminal_height():
     # Return height of terminal as int
     try:
-        width, height = shutil.get_terminal_size((80,40))
+        width, height = shutil.get_terminal_size((80,80))
     except AttributeError:
-        # get_terminal_size is only available in Python >= 3.3. Use default height of 40 if get_terminal_size fails
-        height = 40 
+        # get_terminal_size is only available in Python >= 3.3. Use default height of 80 if get_terminal_size fails
+        height = 80 
 
     return(int(height))
 


### PR DESCRIPTION
If the number of targets exceeded the height of the terminal (number of lines), you couldn't see all the available targets. I have implemented scrolling in the target list to fix this. To get the best experience, you need the shutil.get_terminal_size() function, which was implemented in Python 3.3.

I have also added a simple argument parser to support multiple configuration files, in case there is a need for different menus for servers, switches or other stuff.
